### PR TITLE
Remove "nonempty" option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var mount = new Mount({
       return new Buffer("console.error(" + JSON.stringify(e + "") + ")")
     }
   },
-  mountOptions: ["nonempty"]
+  mountOptions: []
 })
 
 process.on("SIGINT", function () {


### PR DESCRIPTION
Hi, thanks for writing this! I liked your article on [your ES6 setup](http://marijnhaverbeke.nl/blog/my-babel-setup.html), which inspired me to try ES6. 

I tried using `moduleserve` and `distfs` as described in that article. I'm on OS X, using [osxfuse](https://osxfuse.github.io/).

Running `distfs` gave this error:

```
fuse: unknown option `nonempty'
```

Removing "nonempty" seems to fix this, and then everything seems to work well! (Although it does seem a bit iffy about unmounting.)

Just thought I'd share in case this helps someone else wanting to use this on OS X :-)
